### PR TITLE
Fix commit inspection

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -291,7 +291,7 @@ def getDataStructureForGraph(data : list[FullStatSnap], ids : list[int], sceneNa
 
             currfullHash = data[id].fullHash
             if(len(currfullHash)>7):
-                currfullHash = currfullHash[:6]
+                currfullHash = currfullHash[:7]
 
             xLabelList[label].append(currfullHash)
             labelIdInSceneLabelList.append(currLabelIdInSceneLabelList)


### PR DESCRIPTION
The label for commit hash was shorter to what's required for a unique label, so github wasn't able to find the commit sometimes